### PR TITLE
Added SCIM enterprise schema mapping

### DIFF
--- a/SampleData/AttributeMapping.psd1
+++ b/SampleData/AttributeMapping.psd1
@@ -1,9 +1,23 @@
 @{
-    externalId = 'WorkerID'
+    externalId= 'WorkerID'
     name       = @{
         familyName = 'LastName'
         givenName  = 'FirstName'
     }
     active     = { $_.'WorkerStatus' -eq 'Active' }
     userName   = 'UserID'
+    displayName = 'FullName'
+    nickName = 'UserID'
+    userType = 'WorkerType'
+    title = 'JobTitle'
+    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User" = @{
+        employeeNumber = 'WorkerID'
+        costCenter = 'CostCenter'
+        organization = 'Company'
+        division = 'Division'
+        department = 'Department'
+        manager = @{
+            value = 'ManagerID'
+        }
+    }
 }

--- a/src/CSV2SCIM.ps1
+++ b/src/CSV2SCIM.ps1
@@ -219,6 +219,18 @@ function ConvertTo-ScimPayload {
                 }
                 active                                                = Invoke-Transformation $obj $AttributeMapping["active"]
                 userName                                              = $obj.($AttributeMapping["userName"])
+				displayName                                           = $obj.($AttributeMapping["displayName"])
+				"urn:ietf:params:scim:schemas:extension:enterprise:2.0:User" = @{
+					employeeNumber = $obj.($AttributeMapping["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"]["employeeNumber"])
+					costCenter = $obj.($AttributeMapping["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"]["costCenter"])
+					organization = $obj.($AttributeMapping["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"]["organization"])
+					division = $obj.($AttributeMapping["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"]["division"])
+					department = $obj.($AttributeMapping["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"]["department"])
+					"manager" = @{
+						value = $obj.($AttributeMapping["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"]["manager"]["value"])
+					}
+				}
+				
                 "$ScimSchemaNamespace" = $obj
             }
 


### PR DESCRIPTION
Summary of changes: 
1) Added SCIM Enterprise User extension mappings
2) For brevity renamed the main file to: CSV2SCIM (Using command-line options, customers can either just generate the SCIM file or push the generated file to Azure AD). 