### PR TITLE
remove MaximumVersion 1.99.0 requirement Microsoft.Graph.Applications,Microsoft.Graph.Reports

### DIFF
--- a/PowerShell/CSV2SCIM/src/CSV2SCIM.ps1
+++ b/PowerShell/CSV2SCIM/src/CSV2SCIM.ps1
@@ -842,7 +842,7 @@ switch ($PSCmdlet.ParameterSetName) {
         Get-Content -Path $Path -First 1 | Set-AzureADProvisioningAppSchema -ScimSchemaNamespace $ScimSchemaNamespace -ServicePrincipalId $ServicePrincipalId
     }
     'GetPreviousCycleLogs' {
-        Import-Module Microsoft.Graph.Applications,Microsoft.Graph.Reports -MaximumVersion 1.99.0 -ErrorAction Stop
+        Import-Module Microsoft.Graph.Applications,Microsoft.Graph.Reports -ErrorAction Stop
         Connect-MgGraph @paramConnectMgGraph -ErrorAction Stop | Out-Null
        
         Get-ProvisioningCycleIdHistory $ServicePrincipalId -NumberOfCycles $NumberOfCycles | Get-ProvisioningCycleLogs -SummarizeByChangeId -ShowCycleStatistics


### PR DESCRIPTION
The GetPreviousCycleLogs did not work due to requirement regarding MaximumVersion 1.99.0 and the current version of the module is much later. The switchworks I we just remove the MaximumVersion.